### PR TITLE
Fix for schema.org markup

### DIFF
--- a/content.php
+++ b/content.php
@@ -1,7 +1,7 @@
 <?php
 
 $markup_opt = basic_get_theme_option( 'schema_mark' ); // false or 0
-$markup     = ( is_single() && $markup_opt || false === $markup_opt ) ? true : false;
+$markup = ( is_single() && ( $markup_opt || false === $markup_opt ) ) ? true : false;
 
 ?>
 


### PR DESCRIPTION
Если опции в кастомайзере еще ни разу не сохранялись, то выводится микроразметка на анонсах статей (как набор Article) без обобщающего элемента и с ошибкой (отсутствует headline).
заменена строка 4 в content.php
$markup = ( is_single() && $markup_opt || false === $markup_opt ) ? true : false;
на
$markup = ( is_single() && ( $markup_opt || false === $markup_opt ) ) ? true : false;